### PR TITLE
シフト募集定期実行機能 #1

### DIFF
--- a/src/repositories/shift.ts
+++ b/src/repositories/shift.ts
@@ -92,3 +92,33 @@ export async function getShiftSwapLists(){
     .leftJoin(shiftOptions, eq(shifts.shiftId, shiftOptions.id))
     .leftJoin(students, eq(shiftSwapLists.studentsId, students.id));
 }
+
+
+export async function getRecurutingShiftSwapList(){
+  const requesters = aliasedTable(teachers, "requesters");
+  const receivers = aliasedTable(teachers, "receivers");
+  return db.select({
+      id: shiftSwapLists.id,
+      requesterId: shiftSwapLists.requesterId,
+      requesterName: requesters.name,
+      receiverId: shiftSwapLists.receiverId,
+      receiverName: receivers.name,
+      studentId: students.id,
+      studentName: students.name,
+      shiftId: shiftSwapLists.shiftId,
+      shiftDate: shifts.date,
+      shiftTime: shiftOptions.shiftTime,
+      subjectId: shifts.subjectId,
+      subjectsName: subjects.name,
+      reason: shiftSwapLists.reason,
+      status: shiftSwapLists.status,
+  })
+  .from(shiftSwapLists)
+  .leftJoin(requesters, eq(shiftSwapLists.requesterId, requesters.id))
+  .leftJoin(receivers, eq(shiftSwapLists.receiverId, receivers.id))
+  .leftJoin(shifts, eq(shiftSwapLists.shiftId, shifts.id))
+  .leftJoin(subjects, eq(shifts.subjectId, subjects.id))
+  .leftJoin(shiftOptions, eq(shifts.shiftId, shiftOptions.id))
+  .leftJoin(students, eq(shiftSwapLists.studentsId, students.id))
+  .where(eq(shiftSwapLists.status, "pending"));
+}


### PR DESCRIPTION
### 概要

シフト交換募集をメッセージで定期的に実行する機能の実装


![image](https://github.com/user-attachments/assets/f59e8493-1fc9-43d0-9338-2ac0176d54b2)


### 注意事項
* 現在は交換申請がなされたシフトのみだが、管理者が作成したシフト募集も載せられるようにしたい
* 日時の昇順で埋まっていない直近のものから表示させるように変更をしたい